### PR TITLE
Nav sr 2.23.25

### DIFF
--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -82,8 +82,8 @@
 
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
-  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__subnav--RowGap);
-  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__subnav--RowGap);
+  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap);
+  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
   --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
@@ -180,7 +180,7 @@
       .#{$menu}__list {
         row-gap: var(--#{$nav}__subnav--RowGap);
       }
-    
+
       .#{$menu}__list-item::before {
         border-radius: var(--#{$nav}__link--BorderRadius);
       }
@@ -233,7 +233,7 @@
   overflow-y: clip;
   transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows);
   transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
-  transition-property: grid-template-rows, padding-block-start;
+  transition-property: grid-template-rows, padding-block-start, padding-block-end;
   
   &[hidden] {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
@@ -252,16 +252,11 @@
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
   }
 
-  &.pf-m-expanded:is(:not(:only-child, :last-child)) {
-    + .#{$nav}__item > .#{$nav}__link::before {
-      inset-block-start: calc(var(--#{$nav}__item--RowGap) * -1 - var(--#{$nav}__list--RowGap));
-    }
+  &:is(:only-child, :last-child) {
+    --#{$nav}__subnav--PaddingBlockEnd: 0;
   }
 
   &.pf-m-expanded { 
-    --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap);
-    --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
-
     // duration for collapsing needs to set the property rather than the variable because of nested items
     transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap);
   }
@@ -305,11 +300,6 @@
   transition-timing-function: var(--#{$nav}__link--TransitionTimingFunction--background-color), var(--#{$nav}__link--m-current--TransitionTimingFunction--color);
   transition-duration: var(--#{$nav}__link--TransitionDuration--background-color), var(--#{$nav}__link--m-current--TransitionDuration--color);
   transition-property: background-color, color;
-
-  // increase height clickable area of expanded nav_links to account for
-  &[aria-expanded="true"]::before {
-    inset-block-end: calc(var(--#{$nav}__item--RowGap) * -1);
-  }
 
   // explicitly set background-color prop to avoid affecting child elements settings
   &:hover,

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -39,7 +39,6 @@
 
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
-  --#{$nav}__item--m-expanded--TransitionDuration--row-gap: 0;
 
   // * Nav item toggle icon
   --#{$nav}__item__toggle-icon--Rotate: 0;
@@ -76,15 +75,13 @@
   --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap); // needed to keep focus outline on first item from being cut off
   --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap); // needed to keep focus outline on last item from being cut off
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
-  --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
-  --#{$nav}__subnav--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
-  --#{$nav}__subnav--hidden--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--short);
-  --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
-  --#{$nav}__subnav--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+  --#{$nav}__subnav--TransitionDuration--expansion: 0s; // no slide by default
+  --#{$nav}__subnav--hidden--TransitionDuration--expansion: 0;
+  --#{$nav}__subnav--TransitionTimingFunction--expansion: var(--pf-t--global--motion--timing-function--default);
 
   @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--default);
-    --#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
+    --#{$nav}__subnav--TransitionDuration--expansion: var(--pf-t--global--motion--duration--slide-in--default);
+    --#{$nav}__subnav--hidden--TransitionDuration--expansion: var(--pf-t--global--motion--duration--slide-in--short);
   }
 
   // * Nav scroll button
@@ -215,15 +212,14 @@
   padding-block-end: var(--#{$nav}__subnav--PaddingBlockEnd);
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--opacity);
-  transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--opacity);
+  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--expansion);
+  transition-duration: var(--#{$nav}__subnav--TransitionDuration--expansion);
   transition-property: grid-template-rows, padding-block-start, padding-block-end, opacity;
   
   &[hidden] {
-    --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
+    --#{$nav}__subnav--TransitionDuration--expansion: var(--#{$nav}__subnav--hidden--TransitionDuration--expansion);
     --#{$nav}__subnav--PaddingBlockStart: 0;
     --#{$nav}__subnav--PaddingBlockEnd: 0;
-    --#{$nav}__subnav--TransitionDuration--opacity: var(--#{$nav}__subnav--hidden--TransitionDuration--opacity);
 
     grid-template-rows: 0fr;
     opacity: 0;
@@ -242,11 +238,6 @@
     > .#{$nav}__subnav {
       margin-block-end: calc(var(--#{$nav}__subnav--PaddingBlockEnd) * -1); // offset bottom padding
     }
-  }
-
-  &.pf-m-expanded { 
-    // duration for collapsing needs to set the property rather than the variable because of nested items
-    transition-duration: var(--#{$nav}__item--m-expanded--TransitionDuration--row-gap);
   }
 }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -32,8 +32,8 @@
   // * Nav section title
   --#{$nav}__section-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$nav}__section-title--Color: var(--pf-t--global--text--color--regular);
-  --#{$nav}__section-title--PaddingBlockStart: var(--#{$nav}__link--PaddingBlockStart);
-  --#{$nav}__section-title--PaddingBlockEnd: var(--#{$nav}__link--PaddingBlockEnd);
+  --#{$nav}__section-title--PaddingBlockStart: 0;
+  --#{$nav}__section-title--PaddingBlockEnd: 0;
   --#{$nav}__section-title--PaddingInlineStart: var(--#{$nav}__link--PaddingInlineStart);
   --#{$nav}__section-title--PaddingInlineEnd: var(--#{$nav}__link--PaddingInlineEnd);
 
@@ -73,8 +73,8 @@
 
   // * Nav subnav
   --#{$nav}__subnav--RowGap: var(--pf-t--global--border--width--extra-strong);
-  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap);
-  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
+  --#{$nav}__subnav--PaddingBlockStart: var(--#{$nav}__item--RowGap); // needed to keep focus outline on first item from being cut off
+  --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap); // needed to keep focus outline on last item from being cut off
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
   --#{$nav}__subnav--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
@@ -238,8 +238,10 @@
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
   }
 
-  &:last-child {
-    --#{$nav}__subnav--PaddingBlockEnd: 0;
+  &.pf-m-expanded:last-child {
+    > .#{$nav}__subnav {
+      margin-block-end: calc(var(--#{$nav}__subnav--PaddingBlockEnd) * -1); // offset bottom padding
+    }
   }
 
   &.pf-m-expanded { 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -238,7 +238,7 @@
     margin-block-end: var(--#{$nav}__button--RowGap--row-offset);
   }
 
-  &:is(:only-child, :last-child) {
+  &:last-child {
     --#{$nav}__subnav--PaddingBlockEnd: 0;
   }
 

--- a/src/patternfly/components/Nav/nav.scss
+++ b/src/patternfly/components/Nav/nav.scss
@@ -29,11 +29,6 @@
   --#{$nav}__list--ScrollSnapType: var(--#{$nav}__list--ScrollSnapTypeAxis) var(--#{$nav}__list--ScrollSnapTypeStrictness);
   --#{$nav}__item--ScrollSnapAlign: end;
 
-  // Nav list animation variables
-  --#{$nav}__list--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
-  --#{$nav}__list--hidden--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--short);
-  --#{$nav}__list--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
-
   // * Nav section title
   --#{$nav}__section-title--FontWeight: var(--pf-t--global--font--weight--body--bold);
   --#{$nav}__section-title--Color: var(--pf-t--global--text--color--regular);
@@ -45,10 +40,6 @@
   // * Nav item
   --#{$nav}__item--RowGap: var(--#{$nav}__list--RowGap);
   --#{$nav}__item--m-expanded--TransitionDuration--row-gap: 0;
-
-  @media (prefers-reduced-motion: no-preference) {
-    --#{$nav}__item--m-expandedTransitionDuration--row-gap: var(--pf-t--global--motion--duration--slide-in--default);
-  }
 
   // * Nav item toggle icon
   --#{$nav}__item__toggle-icon--Rotate: 0;
@@ -86,8 +77,11 @@
   --#{$nav}__subnav--PaddingBlockEnd: var(--#{$nav}__item--RowGap);
   --#{$nav}__subnav--PaddingInlineStart: var(--pf-t--global--spacer--md);
   --#{$nav}__subnav--TransitionDuration--grid-template-rows: 0s; // no slide by default
+  --#{$nav}__subnav--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--default); // match the duration of the slide open
+  --#{$nav}__subnav--hidden--TransitionDuration--opacity: var(--pf-t--global--motion--duration--slide-in--short);
   --#{$nav}__subnav--TransitionTimingFunction--grid-template-rows: var(--pf-t--global--motion--timing-function--default);
-  
+  --#{$nav}__subnav--TransitionTimingFunction--opacity: var(--pf-t--global--motion--timing-function--default);
+
   @media (prefers-reduced-motion: no-preference) {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--default);
     --#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows: var(--pf-t--global--motion--duration--slide-in--short);
@@ -190,12 +184,6 @@
 
 [class^="#{$nav}"][hidden] {
   visibility: hidden;
-
-  .#{$nav}__list {
-    --#{$nav}__list--TransitionDuration--opacity: var(--#{$nav}__list--hidden--TransitionDuration--opacity);
-
-    opacity: 0;
-  }
 }
 
 // Magic value calcs
@@ -215,10 +203,6 @@
   row-gap: var(--#{$nav}__list--RowGap);
   column-gap: var(--#{$nav}__list--ColumnGap);
   min-height: 0;
-  opacity: 1;
-  transition-timing-function: var(--#{$nav}__list--TransitionTimingFunction--opacity);
-  transition-duration: var(--#{$nav}__list--TransitionDuration--opacity);
-  transition-property: opacity;
 }
 
 // - Nav subnav
@@ -231,16 +215,18 @@
   padding-block-end: var(--#{$nav}__subnav--PaddingBlockEnd);
   padding-inline-start: var(--#{$nav}__subnav--PaddingInlineStart); // indent nested lists
   overflow-y: clip;
-  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows);
-  transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows);
-  transition-property: grid-template-rows, padding-block-start, padding-block-end;
+  transition-timing-function: var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--grid-template-rows), var(--#{$nav}__subnav--TransitionTimingFunction--opacity);
+  transition-duration: var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--grid-template-rows), var(--#{$nav}__subnav--TransitionDuration--opacity);
+  transition-property: grid-template-rows, padding-block-start, padding-block-end, opacity;
   
   &[hidden] {
     --#{$nav}__subnav--TransitionDuration--grid-template-rows: var(--#{$nav}__subnav--hidden--TransitionDuration--grid-template-rows);
     --#{$nav}__subnav--PaddingBlockStart: 0;
     --#{$nav}__subnav--PaddingBlockEnd: 0;
+    --#{$nav}__subnav--TransitionDuration--opacity: var(--#{$nav}__subnav--hidden--TransitionDuration--opacity);
 
     grid-template-rows: 0fr;
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
* Reworks the `__subnav` vars a little to hopefully make it a bit simpler?
* Moves the `__list` opacity animation to `__subnav`.
  * If the intent is to have the opacity match the slide-o-expando animation duration/timing-function, I'd be down with just using a single var for `transition-[duration/timing-function]` for `grid-template-rows`, `padding-[block/start]`, and `opacity`. Right now I've repeated the `grid-template-rows` vars for `grid-template-rows`, `padding-block-start`, and `padding-block-end` (to match what was already there), and added unique vars for `__opacity`.
* Removes some unused CSS
